### PR TITLE
[POT-48, 40] [Feat] Exception 처리 로직 개발 & 커스텀 Exception 정의

### DIFF
--- a/pothole-core/src/main/java/pothole_solution/core/util/exception/CustomException.java
+++ b/pothole-core/src/main/java/pothole_solution/core/util/exception/CustomException.java
@@ -1,11 +1,20 @@
 package pothole_solution.core.util.exception;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CustomException extends RuntimeException {
-
     private final ExceptionStatus status;
+
+    public static final CustomException INVALID_PARAMETER       = new CustomException(ExceptionStatus.INVALID_PARAMETER);
+    public static final CustomException INVALID_URL             = new CustomException(ExceptionStatus.INVALID_URL);
+    public static final CustomException INTERNAL_SERVER_ERROR   = new CustomException(ExceptionStatus.INTERNAL_SERVER_ERROR);
+    public static final CustomException NOT_EXISTED_FILE        = new CustomException(ExceptionStatus.NOT_EXISTED_FILE);
+    public static final CustomException DUPLICATED_EMAIL        = new CustomException(ExceptionStatus.DUPLICATED_EMAIL);
+    public static final CustomException NONE_USER               = new CustomException(ExceptionStatus.NONE_USER);
 }

--- a/pothole-core/src/main/java/pothole_solution/core/util/exception/CustomException.java
+++ b/pothole-core/src/main/java/pothole_solution/core/util/exception/CustomException.java
@@ -1,0 +1,11 @@
+package pothole_solution.core.util.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ExceptionStatus status;
+}

--- a/pothole-core/src/main/java/pothole_solution/core/util/exception/ExceptionStatus.java
+++ b/pothole-core/src/main/java/pothole_solution/core/util/exception/ExceptionStatus.java
@@ -1,0 +1,25 @@
+package pothole_solution.core.util.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionStatus {
+    // common exception
+    INVALID_PARAMETER(BAD_REQUEST, 2000, "잘못된 요청이 존재합니다."),
+    INVALID_URL(BAD_REQUEST, 2001, "잘못된 URL 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 2002,"서버 내부 오류입니다."),
+    NOT_EXISTED_FILE(NOT_EXTENDED, 2003,"존재하지 않는 파일입니다."),
+
+    // user exception
+    DUPLICATED_EMAIL(CONFLICT, 3000, "중복된 이메일이 존재합니다."),
+    NONE_USER(NOT_FOUND, 3001, "존재하지 않는 회원입니다.");
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+}

--- a/pothole-core/src/main/java/pothole_solution/core/util/exception/GlobalExceptionHandler.java
+++ b/pothole-core/src/main/java/pothole_solution/core/util/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package pothole_solution.core.util.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import pothole_solution.core.util.response.BaseResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<Object> handlePotholeException(CustomException e) {
+        ExceptionStatus status = e.getStatus();
+        return ResponseEntity
+                .status(status.getHttpStatus())
+                .body(new BaseResponse<>(status));
+    }
+}

--- a/pothole-core/src/main/java/pothole_solution/core/util/response/BaseResponse.java
+++ b/pothole-core/src/main/java/pothole_solution/core/util/response/BaseResponse.java
@@ -1,0 +1,31 @@
+package pothole_solution.core.util.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import pothole_solution.core.util.exception.ExceptionStatus;
+
+@Getter
+public class BaseResponse<T> {
+
+    private final Boolean isSuccess;
+    private final int code;
+    private final String message;
+
+    @JsonInclude(value = JsonInclude.Include.NON_NULL)
+    private T data;
+
+    // 성공시 반환되는 Response
+    public BaseResponse(T data) {
+        this.isSuccess = true;
+        this.code = 1000;
+        this.message = "요청에 성공하였습니다.";
+        this.data = data;
+    }
+
+    // 실패시 반환되는 Response
+    public BaseResponse(ExceptionStatus status) {
+        this.isSuccess = false;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+    }
+}


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [ ] 변경 사항에 대한 테스트
- [ ] 문서 추가/업데이트


## PR Type

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명: 


## Jira 정보
Jira Code: POT-48, POT-40
Jira Link: [POT-48](https://porthole.atlassian.net/browse/POT-48), [POT-40](https://porthole.atlassian.net/browse/POT-40)


## 작업 내용(기대 효과)
- `BaseResponse<T>` 구현
  - 필드값)
    - `isSuccess`: 성공 여부(boolean)
    - `httpStatus`: 반환될 HttpStatus 상태(ex. 200, 400 등)
    - `code`: 상태 코드. 응답 성공은 기본적으로 1000
    - `data`: 응답 성공시 반환할 데이터
    - `maessage`: 예외 발생시 반환할 예외 메세지
  - 모든 API 응답 및 예외 발생에서 활용할 수 있음.
  - 제네릭(<T>)으로 모든 형태의 응답 데이터를 Json으로 반환할 수 있음.
  - 사용 예시)
  ![image](https://github.com/pothole-developer/pothole-backend/assets/54929830/43bc7393-ae71-4793-8d3c-27ef3baca68c)

- `GlobalExceptionHandler`구현
  - 런타임시 발생하는 모든 `CustomException` 예외를 감지하고 예외 정보에 대한 응답을 반환함.
  - `ExceptionStatus` 에 정의한 모든 예외에 대해 동작함

- `ExceptionStatus` 구현 및 초기화
  - 커스텀 예외를 미리 정의할 수 있는 Enum Class 구현
  - 필드값: `HttpStatus`, `상태 code`, `message`(위 설명과 동일)
  - 예외 추가 방법)
    - 1. Enum 타입의 변수입력
    - 2. 예외에 맞는 HttpStatus, code, Message 입력
    - 3. _CustomException 클래스에 static 필드로 추가_
  - ⚠️ 주의 사항)
    - 도메인 별로 `주석`과 `code`로 묶을것을 권장.
    - 동일 도메인 예외는 code값 순차적으로 입력.(ex. 2000, 2001, 2002 ..)

- `CustomException` 구현
  - `RuntimeException`을 상속받은 커스텀 클래스 구현
  - 필드 값:
    - `Enum ExceptionStatus`
    - `static 필드`: ExceptionStatus에 정의한 모든 enum 변수들을 static 필드로 가짐.(싱글톤 객체로 관리하기 위함.)


## 기타 사항
- 


[POT-48]: https://porthole.atlassian.net/browse/POT-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[POT-40]: https://porthole.atlassian.net/browse/POT-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ