### PR TITLE
[POT-47] [HOTFIX] redis 컨테이너에 접속 못하는 문제 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   session-redis:
     image: redis:alpine
     container_name: session-redis
-    hostname: redis
+    hostname: session-redis
     ports:
       - 6379:6379
     volumes:


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [ ] 변경 사항에 대한 테스트
- [ ] 문서 추가/업데이트


## PR Type

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명: 


## Jira 정보
Jira Code: POT-47
Jira Link: [POT-47](https://porthole.atlassian.net/browse/POT-47)


## 작업 내용(기대 효과)
- `docker-compose.yml`에 `redis`의 `hostName`를 `session-redis`로 설정한 뒤,
spring 에서 redis에 접속할 host 명을 `session-redis`로 명시함
- 다른 컨테이너에서 `redis 컨테이너`에 연결할 수 있음.

## 기타 사항
- 
