### PR TITLE
[POT-47] [FEAT] 포트포워딩을 위한 로그인, 로그아웃 URL 에 PathVariable 추가 구현

### DIFF
--- a/pothole-core/src/main/java/pothole_solution/core/domain/auth/controller/AuthController.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/auth/controller/AuthController.java
@@ -30,21 +30,24 @@ public class AuthController {
         return new BaseResponse<>(responseDto);
     }
 
-    @PostMapping("/login")
-    public BaseResponse<MemberBaseResponseDto> login(@Valid @RequestBody final AuthLoginRequestDto authLoginRequestDto,
+    @PostMapping("/{roleName}/login")
+    public BaseResponse<MemberBaseResponseDto> login(@PathVariable String roleName,
+                                                     @Valid @RequestBody final AuthLoginRequestDto authLoginRequestDto,
                                                      final HttpServletRequest httpServletRequest) {
 
-        MemberBaseResponseDto responseDto = authService.login(authLoginRequestDto, httpServletRequest);
+        MemberBaseResponseDto responseDto = authService.login(roleName, authLoginRequestDto, httpServletRequest);
 
         return new BaseResponse<>(responseDto);
     }
 
-    @PostMapping("/logout")
-    public BaseResponse<MemberBaseResponseDto> logout(@AuthenticationPrincipal PrincipalDetails principalDetails,
+    @PostMapping("/{roleName}/logout")
+    public BaseResponse<MemberBaseResponseDto> logout(@PathVariable String roleName,
+                                                      @AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       final HttpServletRequest httpServletRequest) {
 
         Long memberId = principalDetails.getId();
-        MemberBaseResponseDto responseDto = authService.logout(memberId, httpServletRequest);
+
+        MemberBaseResponseDto responseDto = authService.logout(roleName, memberId, httpServletRequest);
 
         return new BaseResponse<>(responseDto);
     }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/auth/controller/AuthController.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/auth/controller/AuthController.java
@@ -41,14 +41,14 @@ public class AuthController {
     }
 
     @PostMapping("/{roleName}/logout")
-    public BaseResponse<MemberBaseResponseDto> logout(@PathVariable String roleName,
-                                                      @AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                      final HttpServletRequest httpServletRequest) {
+    public BaseResponse<Object> logout(@PathVariable String roleName,
+                                       @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                       final HttpServletRequest httpServletRequest) {
 
         Long memberId = principalDetails.getId();
 
-        MemberBaseResponseDto responseDto = authService.logout(roleName, memberId, httpServletRequest);
+        authService.logout(roleName, memberId, httpServletRequest);
 
-        return new BaseResponse<>(responseDto);
+        return new BaseResponse<>();
     }
 }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthService.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthService.java
@@ -8,5 +8,5 @@ import pothole_solution.core.domain.auth.dto.AuthLoginRequestDto;
 public interface AuthService {
     MemberBaseResponseDto join(String roleName, AuthJoinRequestDto requestDto);
     MemberBaseResponseDto login(String roleName, AuthLoginRequestDto requestDto, HttpServletRequest httpServletRequest);
-    MemberBaseResponseDto logout(String roleName, Long memberId, HttpServletRequest httpServletRequest);
+    void logout(String roleName, Long memberId, HttpServletRequest httpServletRequest);
 }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthService.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthService.java
@@ -7,6 +7,6 @@ import pothole_solution.core.domain.auth.dto.AuthLoginRequestDto;
 
 public interface AuthService {
     MemberBaseResponseDto join(String roleName, AuthJoinRequestDto requestDto);
-    MemberBaseResponseDto login(AuthLoginRequestDto requestDto, HttpServletRequest httpServletRequest);
-    MemberBaseResponseDto logout(Long memberId, HttpServletRequest httpServletRequest);
+    MemberBaseResponseDto login(String roleName, AuthLoginRequestDto requestDto, HttpServletRequest httpServletRequest);
+    MemberBaseResponseDto logout(String roleName, Long memberId, HttpServletRequest httpServletRequest);
 }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthServiceImpl.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthServiceImpl.java
@@ -12,8 +12,10 @@ import pothole_solution.core.domain.auth.dto.AuthLoginRequestDto;
 import pothole_solution.core.domain.member.entity.Member;
 import pothole_solution.core.domain.member.entity.Role;
 import pothole_solution.core.domain.member.service.MemberService;
+import pothole_solution.core.global.exception.CustomException;
 
 import static pothole_solution.core.global.exception.CustomException.MISMATCH_PASSWORD;
+import static pothole_solution.core.global.exception.CustomException.MISMATCH_ROLE;
 
 
 @Service
@@ -44,9 +46,11 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public MemberBaseResponseDto login(AuthLoginRequestDto requestDto, HttpServletRequest request) {
+    public MemberBaseResponseDto login(String roleName, AuthLoginRequestDto requestDto, HttpServletRequest request) {
 
         Member findMember = memberService.findByEmail(requestDto.getEmail());
+
+        matchesRole(roleName, findMember.getRole().name());
 
         matchesPassword(requestDto.getPassword(), findMember.getPassword());
 
@@ -62,10 +66,20 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public MemberBaseResponseDto logout(Long memberId, HttpServletRequest httpServletRequest) {
+    public MemberBaseResponseDto logout(String roleName, Long memberId, HttpServletRequest httpServletRequest) {
+
+        Member findMember = memberService.findById(memberId);
+
+        matchesRole(roleName, findMember.getRole().name());
 
         sessionService.invalidate(httpServletRequest);
 
         return MemberBaseResponseDto.of(memberId);
+    }
+
+    private void matchesRole(String requestRoleName, String memberRoleName) {
+        if (requestRoleName.equals(memberRoleName)) {
+            throw MISMATCH_ROLE;
+        }
     }
 }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthServiceImpl.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/auth/service/AuthServiceImpl.java
@@ -6,13 +6,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import pothole_solution.core.domain.member.dto.MemberBaseResponseDto;
 import pothole_solution.core.domain.auth.dto.AuthJoinRequestDto;
 import pothole_solution.core.domain.auth.dto.AuthLoginRequestDto;
+import pothole_solution.core.domain.member.dto.MemberBaseResponseDto;
 import pothole_solution.core.domain.member.entity.Member;
 import pothole_solution.core.domain.member.entity.Role;
 import pothole_solution.core.domain.member.service.MemberService;
-import pothole_solution.core.global.exception.CustomException;
 
 import static pothole_solution.core.global.exception.CustomException.MISMATCH_PASSWORD;
 import static pothole_solution.core.global.exception.CustomException.MISMATCH_ROLE;
@@ -66,15 +65,13 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public MemberBaseResponseDto logout(String roleName, Long memberId, HttpServletRequest httpServletRequest) {
+    public void logout(String roleName, Long memberId, HttpServletRequest httpServletRequest) {
 
         Member findMember = memberService.findById(memberId);
 
         matchesRole(roleName, findMember.getRole().name());
 
         sessionService.invalidate(httpServletRequest);
-
-        return MemberBaseResponseDto.of(memberId);
     }
 
     private void matchesRole(String requestRoleName, String memberRoleName) {

--- a/pothole-core/src/main/java/pothole_solution/core/domain/member/service/MemberService.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import pothole_solution.core.domain.member.entity.Member;
 
 public interface MemberService {
     Member save(Member joinMember);
+    Member findById(Long memberId);
     Member findByEmail(String email);
     boolean existsByEmail(String email);
     void validateDuplicateEmail(String email);

--- a/pothole-core/src/main/java/pothole_solution/core/domain/member/service/MemberServiceImpl.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/member/service/MemberServiceImpl.java
@@ -9,6 +9,8 @@ import pothole_solution.core.domain.member.entity.Member;
 import pothole_solution.core.domain.member.repository.MemberRepository;
 import pothole_solution.core.global.exception.CustomException;
 
+import static pothole_solution.core.global.exception.CustomException.NONE_USER;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -23,9 +25,15 @@ public class MemberServiceImpl implements MemberService{
     }
 
     @Override
+    public Member findById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> NONE_USER);
+    }
+
+    @Override
     public Member findByEmail(String email) {
         return memberRepository.findByEmail(email)
-                .orElseThrow(() -> CustomException.NONE_USER);
+                .orElseThrow(() -> NONE_USER);
     }
 
     @Override

--- a/pothole-core/src/main/java/pothole_solution/core/global/exception/CustomException.java
+++ b/pothole-core/src/main/java/pothole_solution/core/global/exception/CustomException.java
@@ -27,6 +27,7 @@ public class CustomException extends RuntimeException {
     public static final CustomException NONE_USER               = new CustomException(ExceptionStatus.NONE_USER);
     public static final CustomException MISMATCH_PASSWORD       = new CustomException(ExceptionStatus.MISMATCH_PASSWORD);
     public static final CustomException NONE_ROLE               = new CustomException(ExceptionStatus.NONE_ROLE);
+    public static final CustomException MISMATCH_ROLE               = new CustomException(ExceptionStatus.MISMATCH_ROLE);
 
     // s3 exception
     public static final CustomException NOT_EXISTED_POTHOLE         = new CustomException(ExceptionStatus.NOT_EXISTED_POTHOLE);

--- a/pothole-core/src/main/java/pothole_solution/core/global/exception/ExceptionStatus.java
+++ b/pothole-core/src/main/java/pothole_solution/core/global/exception/ExceptionStatus.java
@@ -25,6 +25,7 @@ public enum ExceptionStatus {
     NONE_USER(NOT_FOUND, 3001, "존재하지 않는 회원입니다."),
     MISMATCH_PASSWORD(UNAUTHORIZED, 3002, "비밀번호가 일치하지 않습니다."),
     NONE_ROLE(NOT_FOUND, 3003, "존재하지 않는 역할 입니다."),
+    MISMATCH_ROLE(UNAUTHORIZED, 3004, "일치하지 않는 역할 입니다."),
 
     // manager exception
     NOT_EXISTED_POTHOLE(NOT_FOUND, 4000, "존재하지 않는 포트홀입니다."),

--- a/pothole-core/src/main/java/pothole_solution/core/infra/config/SecurityConfig.java
+++ b/pothole-core/src/main/java/pothole_solution/core/infra/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizeRequest -> authorizeRequest
                         .requestMatchers(
                                 AntPathRequestMatcher.antMatcher("/pothole/v1/auth/**/join"),
-                                AntPathRequestMatcher.antMatcher("/pothole/v1/auth/login")).permitAll()
+                                AntPathRequestMatcher.antMatcher("/pothole/v1/auth/**/login")).permitAll()
                         .requestMatchers(
                                 AntPathRequestMatcher.antMatcher("/pothole/v1/manager/**")).hasRole("MANAGER")
                         .requestMatchers(


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [ ] 변경 사항에 대한 테스트
- [ ] 문서 추가/업데이트


## PR Type

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경
- [x] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명: 


## Jira 정보
Jira Code: POT-47
Jira Link: [POT-47](https://porthole.atlassian.net/browse/POT-47)


## 작업 내용(기대 효과)
- `로그인`, `로그아웃` 시 URI에 `roleName`을 명시함으로써, 알맞은 모듈에 포트포워딩 될 수 있음(NGINX에 의해).
- + role이 일치하지 않은 URI로 로그인 혹은 로그아웃 시도시 예외 발생
  - ex) `worker` 가 `auth/manager/login` 으로 로그인 시도시 예외 발생

## 기타 사항
- 


[POT-47]: https://porthole.atlassian.net/browse/POT-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ