### PR TITLE
[POT-69] [hotfix] 포트홀 조회 쿼리를 join 에서 left join 으로 변경

### DIFF
--- a/pothole-core/src/main/java/pothole_solution/core/domain/pothole/repository/PotholeRepository.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/pothole/repository/PotholeRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface PotholeRepository extends JpaRepository<Pothole, Long> {
     @Query("select p from Pothole p " +
-            "join fetch p.potholeHistories ph " +
+            "left join fetch p.potholeHistories ph " +
             "where p.potholeId = :potholeId")
     Optional<Pothole> findPotholeWithPotholeHistoryByPotholeId(@Param("potholeId") Long potholeId);
 }


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [ ] 문서 추가/업데이트


## PR Type

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명: 


## Jira 정보
Jira Code:POT-69
Jira Link:https://porthole.atlassian.net/browse/POT-69


## 작업 내용(기대 효과)
- 쿼리 수정
AS-IS
"select p from Pothole p " +
            "join fetch p.potholeHistories ph " +
            "where p.potholeId = :potholeId"
TO-BE
"select p from Pothole p " +
            "left join fetch p.potholeHistories ph " +
            "where p.potholeId = :potholeId"

## 기타 사항
- 
