### PR TITLE
[POT-80] [FIX] 포트홀 응답 데이터에 위험도 추가, 필터링 예외 조건 추가

### DIFF
--- a/pothole-core/src/main/java/pothole_solution/core/domain/pothole/dto/request/ReqPotRegPotMngrServDto.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/pothole/dto/request/ReqPotRegPotMngrServDto.java
@@ -9,41 +9,34 @@ import org.locationtech.jts.geom.GeometryFactory;
 import pothole_solution.core.domain.pothole.entity.Pothole;
 import pothole_solution.core.domain.pothole.entity.Progress;
 
+import java.util.Random;
+
 @Getter
 @NoArgsConstructor
 public class ReqPotRegPotMngrServDto {
-    private String roadName = "None";
-
     @NotNull(message = "위도의 값은 반드시 존재해야 합니다.")
     private double lat;
 
     @NotNull(message = "경도의 값은 반드시 존재해야 합니다.")
     private double lon;
 
-    private Integer dangerous;
-
-    private Integer importance;
-
     @Builder
-    public ReqPotRegPotMngrServDto(String roadName, double lat, double lon, Integer dangerous, Integer importance) {
-        if (roadName != null) {
-            this.roadName = roadName;
-        }
-
+    public ReqPotRegPotMngrServDto(double lat, double lon) {
         this.lat = lat;
         this.lon = lon;
-        this.importance = importance;
-        this.dangerous = dangerous;
     }
 
     public Pothole toPothole() {
         GeometryFactory geometryFactory = new GeometryFactory();
 
+        Integer randomImportance = new Random().nextInt(101);
+        Integer randomDangerous = new Random().nextInt(101);
+
         return Pothole.builder()
-                .roadName(roadName)
+                .roadName("강남로 1")
                 .point(geometryFactory.createPoint(new Coordinate(lon, lat)))
-                .importance(importance)
-                .dangerous(dangerous)
+                .importance(randomImportance)
+                .dangerous(randomDangerous)
                 .processStatus(Progress.REGISTER)
                 .build();
     }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/pothole/dto/request/ReqPotRegPotMngrServDto.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/pothole/dto/request/ReqPotRegPotMngrServDto.java
@@ -9,34 +9,41 @@ import org.locationtech.jts.geom.GeometryFactory;
 import pothole_solution.core.domain.pothole.entity.Pothole;
 import pothole_solution.core.domain.pothole.entity.Progress;
 
-import java.util.Random;
-
 @Getter
 @NoArgsConstructor
 public class ReqPotRegPotMngrServDto {
+    private String roadName = "None";
+
     @NotNull(message = "위도의 값은 반드시 존재해야 합니다.")
     private double lat;
 
     @NotNull(message = "경도의 값은 반드시 존재해야 합니다.")
     private double lon;
 
+    private Integer dangerous;
+
+    private Integer importance;
+
     @Builder
-    public ReqPotRegPotMngrServDto(double lat, double lon) {
+    public ReqPotRegPotMngrServDto(String roadName, double lat, double lon, Integer dangerous, Integer importance) {
+        if (roadName != null) {
+            this.roadName = roadName;
+        }
+
         this.lat = lat;
         this.lon = lon;
+        this.importance = importance;
+        this.dangerous = dangerous;
     }
 
     public Pothole toPothole() {
         GeometryFactory geometryFactory = new GeometryFactory();
 
-        Integer randomImportance = new Random().nextInt(101);
-        Integer randomDangerous = new Random().nextInt(101);
-
         return Pothole.builder()
-                .roadName("강남로 1")
+                .roadName(roadName)
                 .point(geometryFactory.createPoint(new Coordinate(lon, lat)))
-                .importance(randomImportance)
-                .dangerous(randomDangerous)
+                .importance(importance)
+                .dangerous(dangerous)
                 .processStatus(Progress.REGISTER)
                 .build();
     }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/pothole/dto/response/RespPotSimInfoPotMngrCntrDto.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/pothole/dto/response/RespPotSimInfoPotMngrCntrDto.java
@@ -15,6 +15,7 @@ public class RespPotSimInfoPotMngrCntrDto {
     private double lon;
     private String thumbnail;
     private Integer importance;
+    private Integer dangerous;
     private Progress progressStatus;
 
     @Builder
@@ -25,6 +26,7 @@ public class RespPotSimInfoPotMngrCntrDto {
         this.lon = pothole.getPoint().getX();
         this.thumbnail = pothole.getThumbnail();
         this.importance = pothole.getImportance();
+        this.dangerous = pothole.getDangerous();
         this.progressStatus = pothole.getProcessStatus();
     }
 }

--- a/pothole-core/src/main/java/pothole_solution/core/domain/pothole/repository/PotholeQueryDslRepository.java
+++ b/pothole-core/src/main/java/pothole_solution/core/domain/pothole/repository/PotholeQueryDslRepository.java
@@ -4,9 +4,9 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import pothole_solution.core.domain.pothole.entity.Progress;
 import pothole_solution.core.domain.pothole.dto.PotFltPotMngrServDto;
 import pothole_solution.core.domain.pothole.entity.Pothole;
+import pothole_solution.core.domain.pothole.entity.Progress;
 
 import java.util.List;
 
@@ -63,7 +63,7 @@ public class PotholeQueryDslRepository {
         BooleanBuilder booleanBuilder = new BooleanBuilder();
 
         // 도로명 입력
-        if (roadName != null) {
+        if (roadName != null && !roadName.isBlank()) {
             booleanBuilder.and(pothole.roadName.eq(roadName));
         }
 


### PR DESCRIPTION
## PR Checklist

- [x] Commit Convention
- [x] 변경 사항에 대한 테스트
- [x] 문서 추가/업데이트


## PR Type

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련
- [ ] CI 관련
- [ ] 문서 내용 변경
- [ ] 기타... 설명: 


## Jira 정보
Jira Code: POT-80
Jira Link: https://porthole.atlassian.net/browse/POT-80


## 작업 내용(기대 효과)
### - RespPotSimInfoPotMngrCntrDto
위험도를 함께 응답하도록 dangerous 추가
<img width="411" alt="image" src="https://github.com/user-attachments/assets/dfcf2d70-487f-40da-a8bc-abcbc702e71a">

### - PotholeQueryDslRepository
roadName 이 비어있거나 빈 칸일 때, 필터링 조건에서 제외하도록 추가
<img width="422" alt="image" src="https://github.com/user-attachments/assets/6de716f5-fb75-4853-a9ac-2e6bf2b28801">